### PR TITLE
Add macOS minimal version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "nabla-ios",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v13), .macOS(.v10_15),
     ],
     products: [
         .library(


### PR DESCRIPTION
Just specifying a minimal platform version number for macOS, this makes the package usable in multi platform packages. My use case is build plugin / commands which are built for the host. Sadly as SPM only has one dependency graph it must be correct even if the targets are not used for some platforms. Because you depend on other packages that require a greater macOS version than the default one, your Package.swift isn't valid when considering macOS. I simply set the highest required version of your dependencies